### PR TITLE
Fix: absolute URLs and empty href

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stack-spot/citron-navigator",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@testing-library/react": "^15.0.7",
+    "@testing-library/user-event": "^14.5.2",
     "@types/jest": "^29.5.12",
     "@types/react": "18.2.66",
     "@types/react-dom": "18.2.22",

--- a/packages/runtime/test/Link.spec.tsx
+++ b/packages/runtime/test/Link.spec.tsx
@@ -1,8 +1,8 @@
-import { fireEvent, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { Link } from '../src/Link'
 import { NavigatorMock } from './NavigatorMock'
 import { RootRoute } from './routes'
-import { delay } from './utils'
 
 describe('Link', () => {
   const root = new RootRoute()
@@ -12,6 +12,21 @@ describe('Link', () => {
     navigator.reset()
     history.replaceState(null, '', 'http://localhost/')
   })
+
+  async function shouldActLikeSimpleAnchor(href?: string, expectedUrl?: string, target?: React.HTMLAttributeAnchorTarget) {
+    const user = userEvent.setup()
+    const onWrapperEvent = jest.fn((event: React.UIEvent) => expect(event.defaultPrevented).toBe(false))
+    const rendered = render(
+      <div onClick={onWrapperEvent} onKeyDown={onWrapperEvent}>
+        <Link data-testid="link" href={href} target={target}>Test</Link>
+      </div>
+    )
+    const anchor = await rendered.findByTestId('link')
+    await user.click(anchor)
+    expect(onWrapperEvent).toHaveBeenCalled()
+    expect(navigator.updateRoute).not.toHaveBeenCalled()
+    if (expectedUrl) expect(location.href).toBe(expectedUrl)
+  }
 
   describe('URLs without hash', () => {
     beforeAll(() => {
@@ -26,23 +41,32 @@ describe('Link', () => {
       expect(anchor.getAttribute('class')).toBe('class')
     })
 
-    async function shouldNavigateAndNotRefresh(event: Event) {
-      const rendered = render(<Link data-testid="link" href="/test">Test</Link>)
+    async function shouldNavigateAndNotRefresh(
+      fireUserEvent: (element: HTMLElement) => Promise<void>,
+      target?: React.HTMLAttributeAnchorTarget,
+    ) {
+      const onWrapperEvent = jest.fn((event: React.UIEvent) => expect(event.defaultPrevented).toBe(true))
+      const rendered = render(
+        <div onClick={onWrapperEvent} onKeyDown={onWrapperEvent}>
+          <Link data-testid="link" href="/test" target={target}>Test</Link>
+        </div>
+      )
       const anchor = await rendered.findByTestId('link')
-      event.preventDefault = jest.fn(event.preventDefault)
-      fireEvent(anchor, event)
-      await delay()
+      await fireUserEvent(anchor)
+      expect(onWrapperEvent).toHaveBeenCalled()
       expect(navigator.updateRoute).toHaveBeenCalled()
       expect(location.href).toBe('http://localhost/test')
-      expect(event.preventDefault).toHaveBeenCalled()
     }
   
-    test('should navigate and not refresh when clicked', () => shouldNavigateAndNotRefresh(new MouseEvent('click')))
+    test('should navigate and not refresh when clicked', () => shouldNavigateAndNotRefresh((element) => {
+      const user = userEvent.setup()
+      return user.click(element)
+    }))
 
-    test(
-      'should navigate and not refresh when enter is pressed',
-      () => shouldNavigateAndNotRefresh(new KeyboardEvent('keydown', { key: 'Enter' })),
-    )
+    test('should navigate and not refresh when clicked', () => shouldNavigateAndNotRefresh((element) => {
+      const user = userEvent.setup()
+      return user.click(element)
+    }))
 
     test('should create link from route and params', async () => {
       const rendered = render(<Link data-testid="link" to={root.studios.studio} params={{ studioId: '1' }}>Studio 1</Link>)
@@ -50,17 +74,16 @@ describe('Link', () => {
       expect(anchor.getAttribute('href')).toBe('/studios/1')
     })
 
-    test('should open in another context (target != _self)', async () => {
-      const rendered = render(<Link data-testid="link" href="/test" target="_blank">Test</Link>)
-      const anchor = await rendered.findByTestId('link')
-      const event = new MouseEvent('click')
-      event.preventDefault = jest.fn(event.preventDefault)
-      fireEvent(anchor, event)
-      await delay()
-      expect(navigator.updateRoute).not.toHaveBeenCalled()
-      expect(location.href).toBe('http://localhost/')
-      expect(event.preventDefault).not.toHaveBeenCalled()
-    })
+    test('should navigate and not refresh when target is _self', () => shouldNavigateAndNotRefresh((element) => {
+      const user = userEvent.setup()
+      return user.click(element)
+    }, '_self'))
+
+    test('should act like simple anchor when target is _blank', () => shouldActLikeSimpleAnchor('/test', 'http://localhost/', '_blank'))
+
+    test('should act like simple anchor when target is _parent', () => shouldActLikeSimpleAnchor('/test', 'http://localhost/', '_parent'))
+
+    test('should act like simple anchor when target is _top', () => shouldActLikeSimpleAnchor('/test', 'http://localhost/', '_top'))
   })
 
   describe('URLs with hash', () => {
@@ -76,22 +99,22 @@ describe('Link', () => {
       expect(anchor.getAttribute('class')).toBe('class')
     })
   
-    test('should act like simple anchor when clicked', async () => {
-      const rendered = render(<Link data-testid="link" href="/#/test">Test</Link>)
-      const anchor = await rendered.findByTestId('link')
-      const event = new MouseEvent('click')
-      event.preventDefault = jest.fn(event.preventDefault)
-      fireEvent(anchor, event)
-      await delay()
-      expect(navigator.updateRoute).not.toHaveBeenCalled()
-      expect(location.href).toBe('http://localhost/#/test')
-      expect(event.preventDefault).not.toHaveBeenCalled()
-    })
+    test('should act like simple anchor when clicked (/#/)', () => shouldActLikeSimpleAnchor('/#/test', 'http://localhost/#/test'))
+
+    test('should act like simple anchor when clicked (#/)', () => shouldActLikeSimpleAnchor('#/test', 'http://localhost/#/test'))
 
     test('should create link from route and params', async () => {
       const rendered = render(<Link data-testid="link" to={root.studios.studio} params={{ studioId: '1' }}>Studio 1</Link>)
       const anchor = await rendered.findByTestId('link')
       expect(anchor.getAttribute('href')).toBe('/#/studios/1')
     })
+  })
+
+  describe('Absolute URLs', () => {
+    test('should act like simple anchor when clicked', () => shouldActLikeSimpleAnchor('https://www.google.com'))
+  })
+
+  describe('Empty href', () => {
+    test('should act like simple anchor when clicked', () => shouldActLikeSimpleAnchor())
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@testing-library/react':
         specifier: ^15.0.7
         version: 15.0.7(@types/react@18.2.66)(react-dom@18.3.1)(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.5.2(@testing-library/dom@10.1.0)
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.12
@@ -1289,6 +1292,15 @@ packages:
       '@types/react-dom': 18.2.22
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+    dev: true
+
+  /@testing-library/user-event@14.5.2(@testing-library/dom@10.1.0):
+    resolution: {integrity: sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+    dependencies:
+      '@testing-library/dom': 10.1.0
     dev: true
 
   /@tootallnate/once@2.0.0:


### PR DESCRIPTION
- Fixes the type of `LinkFn`;
- Makes it so Links with empty href or absolute URLs act like the native `a` element instead of a navigation of Citron.