### PR TITLE
feat: ability to merge routes when using modular navigation 

### DIFF
--- a/docs/modular.md
+++ b/docs/modular.md
@@ -26,7 +26,7 @@ wildcard.
 In a module, we must tell the navigator this is a module and where it should attach itself in the host application. Let's take the module `account`
 as an example.
 
-All the routes of the module `account` must replace the route named `root.account` in the host application. We declare this in the `navigation.yaml`
+All the routes of the module `account` must attached to the route named `root.account` in the host application. We declare this in the `navigation.yaml`
 of the module:
 
 ```yaml
@@ -40,6 +40,7 @@ of the module:
 In the module `application` we'll access the routes normally, but when running in a modular environment, the navigator will know that the root route
 of this module must replace `root.account` in the parent. The character `~` is what indicates the link between the module and the host.
 
-- NOTE 1: when running `application` as a standalone app, the route `/` will result in a 404, since our root is actually at the path `/account`.
-- NOTE 2: the host navigator will accept everything under `account/` until the module is loaded. When it is loaded, the wildcard is replaced by the
+- NOTE 1: if the route in the host already had children, the child routes are copied over to the new route, created by the module.
+- NOTE 2: when running `application` as a standalone app, the route `/` will result in a 404, since our root is actually at the path `/account`.
+- NOTE 3: the host navigator will accept everything under `account/` until the module is loaded. When it is loaded, the wildcard is replaced by the
 actual route (from the module) and any attempt to access an invalid route will result in a 404.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stack-spot/citron-navigator-cli",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "license": "Apache-2.0",
   "homepage": "https://github.com/stack-spot/citron-navigator",

--- a/packages/cli/src/Codegen.ts
+++ b/packages/cli/src/Codegen.ts
@@ -161,8 +161,8 @@ export class Codegen {
         : { route: ContextualizedRoute<RouteByKey[T], RouteParams[T]>, params: RouteParams[T] }
 
       interface NavigationContext {
-        when: <T extends keyof RouteParams>(key: T, handler: (props: ViewPropsOf<T>) => VoidOrPromise) => NavigationContext,
-        whenSubrouteOf: <T extends keyof RouteParams>(key: T, handler: (props: ViewPropsOf<T>) => VoidOrPromise) => NavigationContext,
+        when: <T extends keyof RouteParams>(key: T | T[], handler: (props: ViewPropsOf<T>) => VoidOrPromise) => NavigationContext,
+        whenSubrouteOf: <T extends keyof RouteParams>(key: T | T[], handler: (props: ViewPropsOf<T>) => VoidOrPromise) => NavigationContext,
         otherwise: (handler: () => VoidOrPromise) => NavigationContext,
         whenNotFound: (handler: (path: string) => VoidOrPromise) => NavigationContext,
       }
@@ -170,11 +170,13 @@ export class Codegen {
       function buildContext(clauses: NavigationClauses) {
         const context: NavigationContext = {
           when: (key, handler) => {
-            clauses.when[key] = handler
+            const keys = Array.isArray(key) ? key : [key]
+            keys.forEach(k => clauses.when[k] = handler)
             return context
           },
           whenSubrouteOf: (key, handler) => {
-            clauses.whenSubrouteOf.push({ key, handler })
+            const keys = Array.isArray(key) ? key : [key]
+            keys.forEach(k => clauses.whenSubrouteOf.push({ key: k, handler }))
             return context
           },
           otherwise: (handler) => {

--- a/packages/cli/test/__snapshots__/generate.spec.ts.snap
+++ b/packages/cli/test/__snapshots__/generate.spec.ts.snap
@@ -97,8 +97,8 @@ export type ViewPropsOf<T extends keyof RouteParams> = RouteParams[T] extends vo
     : { route: ContextualizedRoute<RouteByKey[T], RouteParams[T]>, params: RouteParams[T] }
 
 interface NavigationContext {
-    when: <T extends keyof RouteParams>(key: T, handler: (props: ViewPropsOf<T>) => VoidOrPromise) => NavigationContext,
-    whenSubrouteOf: <T extends keyof RouteParams>(key: T, handler: (props: ViewPropsOf<T>) => VoidOrPromise) => NavigationContext,
+    when: <T extends keyof RouteParams>(key: T | T[], handler: (props: ViewPropsOf<T>) => VoidOrPromise) => NavigationContext,
+    whenSubrouteOf: <T extends keyof RouteParams>(key: T | T[], handler: (props: ViewPropsOf<T>) => VoidOrPromise) => NavigationContext,
     otherwise: (handler: () => VoidOrPromise) => NavigationContext,
     whenNotFound: (handler: (path: string) => VoidOrPromise) => NavigationContext,
 }
@@ -106,11 +106,13 @@ interface NavigationContext {
 function buildContext(clauses: NavigationClauses) {
     const context: NavigationContext = {
         when: (key, handler) => {
-            clauses.when[key] = handler
+            const keys = Array.isArray(key) ? key : [key]
+            keys.forEach(k => clauses.when[k] = handler)
             return context
         },
         whenSubrouteOf: (key, handler) => {
-            clauses.whenSubrouteOf.push({ key, handler })
+            const keys = Array.isArray(key) ? key : [key]
+            keys.forEach(k => clauses.whenSubrouteOf.push({ key: k, handler }))
             return context
         },
         otherwise: (handler) => {
@@ -296,8 +298,8 @@ export type ViewPropsOf<T extends keyof RouteParams> = RouteParams[T] extends vo
     : { route: ContextualizedRoute<RouteByKey[T], RouteParams[T]>, params: RouteParams[T] }
 
 interface NavigationContext {
-    when: <T extends keyof RouteParams>(key: T, handler: (props: ViewPropsOf<T>) => VoidOrPromise) => NavigationContext,
-    whenSubrouteOf: <T extends keyof RouteParams>(key: T, handler: (props: ViewPropsOf<T>) => VoidOrPromise) => NavigationContext,
+    when: <T extends keyof RouteParams>(key: T | T[], handler: (props: ViewPropsOf<T>) => VoidOrPromise) => NavigationContext,
+    whenSubrouteOf: <T extends keyof RouteParams>(key: T | T[], handler: (props: ViewPropsOf<T>) => VoidOrPromise) => NavigationContext,
     otherwise: (handler: () => VoidOrPromise) => NavigationContext,
     whenNotFound: (handler: (path: string) => VoidOrPromise) => NavigationContext,
 }
@@ -305,11 +307,13 @@ interface NavigationContext {
 function buildContext(clauses: NavigationClauses) {
     const context: NavigationContext = {
         when: (key, handler) => {
-            clauses.when[key] = handler
+            const keys = Array.isArray(key) ? key : [key]
+            keys.forEach(k => clauses.when[k] = handler)
             return context
         },
         whenSubrouteOf: (key, handler) => {
-            clauses.whenSubrouteOf.push({ key, handler })
+            const keys = Array.isArray(key) ? key : [key]
+            keys.forEach(k => clauses.whenSubrouteOf.push({ key: k, handler }))
             return context
         },
         otherwise: (handler) => {
@@ -580,8 +584,8 @@ export type ViewPropsOf<T extends keyof RouteParams> = RouteParams[T] extends vo
     : { route: ContextualizedRoute<RouteByKey[T], RouteParams[T]>, params: RouteParams[T] }
 
 interface NavigationContext {
-    when: <T extends keyof RouteParams>(key: T, handler: (props: ViewPropsOf<T>) => VoidOrPromise) => NavigationContext,
-    whenSubrouteOf: <T extends keyof RouteParams>(key: T, handler: (props: ViewPropsOf<T>) => VoidOrPromise) => NavigationContext,
+    when: <T extends keyof RouteParams>(key: T | T[], handler: (props: ViewPropsOf<T>) => VoidOrPromise) => NavigationContext,
+    whenSubrouteOf: <T extends keyof RouteParams>(key: T | T[], handler: (props: ViewPropsOf<T>) => VoidOrPromise) => NavigationContext,
     otherwise: (handler: () => VoidOrPromise) => NavigationContext,
     whenNotFound: (handler: (path: string) => VoidOrPromise) => NavigationContext,
 }
@@ -589,11 +593,13 @@ interface NavigationContext {
 function buildContext(clauses: NavigationClauses) {
     const context: NavigationContext = {
         when: (key, handler) => {
-            clauses.when[key] = handler
+            const keys = Array.isArray(key) ? key : [key]
+            keys.forEach(k => clauses.when[k] = handler)
             return context
         },
         whenSubrouteOf: (key, handler) => {
-            clauses.whenSubrouteOf.push({ key, handler })
+            const keys = Array.isArray(key) ? key : [key]
+            keys.forEach(k => clauses.whenSubrouteOf.push({ key: k, handler }))
             return context
         },
         otherwise: (handler) => {
@@ -864,8 +870,8 @@ export type ViewPropsOf<T extends keyof RouteParams> = RouteParams[T] extends vo
     : { route: ContextualizedRoute<RouteByKey[T], RouteParams[T]>, params: RouteParams[T] }
 
 interface NavigationContext {
-    when: <T extends keyof RouteParams>(key: T, handler: (props: ViewPropsOf<T>) => VoidOrPromise) => NavigationContext,
-    whenSubrouteOf: <T extends keyof RouteParams>(key: T, handler: (props: ViewPropsOf<T>) => VoidOrPromise) => NavigationContext,
+    when: <T extends keyof RouteParams>(key: T | T[], handler: (props: ViewPropsOf<T>) => VoidOrPromise) => NavigationContext,
+    whenSubrouteOf: <T extends keyof RouteParams>(key: T | T[], handler: (props: ViewPropsOf<T>) => VoidOrPromise) => NavigationContext,
     otherwise: (handler: () => VoidOrPromise) => NavigationContext,
     whenNotFound: (handler: (path: string) => VoidOrPromise) => NavigationContext,
 }
@@ -873,11 +879,13 @@ interface NavigationContext {
 function buildContext(clauses: NavigationClauses) {
     const context: NavigationContext = {
         when: (key, handler) => {
-            clauses.when[key] = handler
+            const keys = Array.isArray(key) ? key : [key]
+            keys.forEach(k => clauses.when[k] = handler)
             return context
         },
         whenSubrouteOf: (key, handler) => {
-            clauses.whenSubrouteOf.push({ key, handler })
+            const keys = Array.isArray(key) ? key : [key]
+            keys.forEach(k => clauses.whenSubrouteOf.push({ key: k, handler }))
             return context
         },
         otherwise: (handler) => {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stack-spot/citron-navigator",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -8,6 +8,7 @@
   "homepage": "https://github.com/stack-spot/citron-navigator",
   "scripts": {
     "build": "rimraf dist && tsc --project tsconfig.build.json --declaration && tsc-esm-fix --target='dist'",
+    "test": "jest",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "copy-readme": "ts-node ../../scripts/copy-readme.ts",
     "prepublishOnly": "pnpm copy-readme"

--- a/packages/runtime/src/Route.ts
+++ b/packages/runtime/src/Route.ts
@@ -41,7 +41,10 @@ interface GoOptions {
 export type AnyRoute = Route<any, any, any>
 
 /**
- * A Route of the Citron Navigator. The root route, i.e. the route that has no parent will be Navigation Tree.
+ * A Route of the Citron Navigator. The root route, i.e. the route that has no parent will be the Navigation Tree.
+ * 
+ * Routes are equal if they have the same key. To test route equality, use `routeA.equals(routeB)`, do not use same-value-zero equality
+ * (`routeA === routeB`).
  * 
  * Every property of this class not prefixed with "$" is a child route.
  */
@@ -143,6 +146,15 @@ export abstract class Route<
    */
   $is(key: RouteKey): boolean {
     return this.$key === key
+  }
+
+  /**
+   * Checks if the route passed as parameter is equivalent to the this route.
+   * @param route the route to compare.
+   * @returns true if it's  equivalent, false otherwise.
+   */
+  $equals(route: AnyRoute) {
+    return this.$key === route.$key
   }
 
   /**

--- a/packages/runtime/src/errors.ts
+++ b/packages/runtime/src/errors.ts
@@ -3,3 +3,9 @@ export class NavigationError extends Error {
     super(`Navigation error: ${message}`)
   }
 }
+
+export class NavigationSetupError extends Error {
+  constructor(message: string) {
+    super(`Navigation setup error: ${message}`)
+  }
+}

--- a/packages/runtime/test/routes.ts
+++ b/packages/runtime/test/routes.ts
@@ -73,6 +73,22 @@ export class AlternativeRootRoute extends Route<undefined, RouteParams['root']> 
   workspaces = new WorkspacesRoute(this)
 }
 
+export class AlternativeRootRouteWithStudios extends Route<undefined, RouteParams['root']> {
+  constructor() {
+    super('root', '/', undefined, {})
+  }
+
+  studios = new AlternativeStudiosRoute(this)
+}
+
+export class AlternativeRootRouteWithPathClash extends Route<undefined, RouteParams['root']> {
+  constructor() {
+    super('root', '/', undefined, {})
+  }
+
+  foo = new StudiosPathClashRoute(this)
+}
+
 export class WorkspacesRoute extends Route<AlternativeRootRoute, void> {
   constructor(parent: AlternativeRootRoute) {
     super('root.workspaces', '/workspaces/*', parent, {})
@@ -159,6 +175,18 @@ export class StudiosRoute extends Route<RootRoute, RouteParams['root.studios']> 
   }
 
   studio = new StudioRoute(this)
+}
+
+export class AlternativeStudiosRoute extends Route<AlternativeRootRouteWithStudios, RouteParams['root.studios']> {
+  constructor(parent: AlternativeRootRouteWithStudios) {
+    super('root.studios', '/foo', parent, { like: 'string', limit: 'number' })
+  }
+}
+
+export class StudiosPathClashRoute extends Route<AlternativeRootRouteWithPathClash, RouteParams['root.studios']> {
+  constructor(parent: AlternativeRootRouteWithPathClash) {
+    super('root.foo', '/studios', parent, { like: 'string', limit: 'number' })
+  }
 }
 
 class StudioRoute extends Route<StudiosRoute, RouteParams['root.studios.studio']> {

--- a/packages/sample/package.json
+++ b/packages/sample/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "@stack-spot/citron-navigator": "^1.1.0"
+    "@stack-spot/citron-navigator": "^1.3.0"
   },
   "devDependencies": {
     "@types/react": "18.2.66",
@@ -26,6 +26,6 @@
     "eslint-plugin-react-refresh": "^0.4.6",
     "typescript": "^5.2.2",
     "vite": "^5.2.0",
-    "@stack-spot/citron-navigator-cli": "^1.0.0"
+    "@stack-spot/citron-navigator-cli": "^1.1.0"
   }
 }

--- a/packages/sample/package.json
+++ b/packages/sample/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "@stack-spot/citron-navigator": "^1.3.0"
+    "@stack-spot/citron-navigator": "workspace:latest"
   },
   "devDependencies": {
     "@types/react": "18.2.66",
@@ -26,6 +26,6 @@
     "eslint-plugin-react-refresh": "^0.4.6",
     "typescript": "^5.2.2",
     "vite": "^5.2.0",
-    "@stack-spot/citron-navigator-cli": "^1.1.0"
+    "@stack-spot/citron-navigator-cli": "workspace:latest"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,8 +153,8 @@ importers:
   packages/sample:
     dependencies:
       '@stack-spot/citron-navigator':
-        specifier: ^1.1.0
-        version: 1.2.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: workspace:latest
+        version: link:../runtime
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -163,8 +163,8 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@stack-spot/citron-navigator-cli':
-        specifier: ^1.0.0
-        version: 1.0.0(typescript@5.4.5)
+        specifier: workspace:latest
+        version: link:../cli
       '@types/react':
         specifier: 18.2.66
         version: 18.2.66
@@ -759,16 +759,6 @@ packages:
 
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
-
-  '@stack-spot/citron-navigator-cli@1.0.0':
-    resolution: {integrity: sha512-Mj9pdSwqGQEF5SsAoXhg9mIu1aoNTQ8Ja6M93PzbxjmZtr4DM5ghlqa9z5WhDb3oiONJ3pwvk8MWnLHMgefSUg==}
-    hasBin: true
-
-  '@stack-spot/citron-navigator@1.2.0':
-    resolution: {integrity: sha512-6Iv7M/8n9Ot3fjrvQUunoKl/ZBiwI1BoMPyd7SBZYpUkA6TZaUlt78ufmPpQKwBkQNvaYHjNpK6FT4+2+qe5wg==}
-    peerDependencies:
-      react: '>=18.2.0'
-      react-dom: '>=18.2.0'
 
   '@testing-library/dom@10.1.0':
     resolution: {integrity: sha512-wdsYKy5zupPyLCW2Je5DLHSxSfbIp6h80WoHOQc+RPtmPGA52O9x5MJEkv92Sjonpq+poOAtUKhh1kBGAXBrNA==}
@@ -3611,19 +3601,6 @@ snapshots:
   '@sinonjs/fake-timers@10.3.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
-
-  '@stack-spot/citron-navigator-cli@1.0.0(typescript@5.4.5)':
-    dependencies:
-      typescript-formatter: 7.2.2(typescript@5.4.5)
-      yaml: 2.4.3
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - typescript
-
-  '@stack-spot/citron-navigator@1.2.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
 
   '@testing-library/dom@10.1.0':
     dependencies:


### PR DESCRIPTION
### Problem
Modular navigation was first thought in a way each module adds one, and only one subroute. For instance:

- microfront account: adds /account/* to the navigator;
- microfront studios: adds /studios/* to the navigator;
- microfront api-manager: adds /api-manager/* to the navigator;
- and so on...

In actuality, this is is not true, since we can have a microfront that adds more than one route. Considering the stackspot portal, we want the microfront EDP to add multiple routes under the root. With the current behavior, we'd need to change the edp routes to live under `/edp/*` instead of `/*`.

The ideal way of dealing with modular navigation is having each microfront in a different subroute, since this prevents any microfront from defining the same routes as another microfront (route conflict). Unfortunately, this is not always possible and for this reason we need to support more scenarios.

### Solution
Until now, it wasn't allowed for a dynamic route in the parent (host) to have children. A dynamic route is a route without much information that is expected to be replaced by another route in a module. This has been changed, now, the parent route can have children and instead of just replacing it, we replace it and then copy every route that already existed to the new route.

This allows us to extend the root route of the host and merge new routes into it, which solves the problem without creating any breaking change.

### Extra (1)
Within a micro front-end architecture, it is very common to have the same behavior for different routes, to make the code more readable, the functions `when` and `whenSubrouteOf` have been changed to also accept an array of route keys, instead of a single route key.

### Extra (2)
Utility method `equals` for the class `Route`.