### PR TITLE
Fix: modular tree merge

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stack-spot/citron-navigator",
-  "version": "1.3.1-beta.1",
+  "version": "1.3.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stack-spot/citron-navigator",
-  "version": "1.3.0",
+  "version": "1.3.1-beta.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/runtime/src/CitronNavigator.ts
+++ b/packages/runtime/src/CitronNavigator.ts
@@ -88,8 +88,10 @@ export class CitronNavigator {
     })
     // copy all the child routes that existed in the old route, but don't exist in the new one (merge):
     Object.keys(oldRoute).forEach((key) => {
-      // @ts-ignore
-      if (!key.startsWith('$') && !(key in route) && oldRoute[key] instanceof Route) route[key] = oldRoute[key]
+      if (!key.startsWith('$') && !(key in route) && oldRoute[key] instanceof Route) {
+        oldRoute[key].$parent = route
+        route[key as keyof typeof route] = oldRoute[key]
+      }
     })
     this.updateRoute()
   }

--- a/packages/runtime/test/CitronNavigator.spec.ts
+++ b/packages/runtime/test/CitronNavigator.spec.ts
@@ -63,8 +63,11 @@ describe('Citron Navigator', () => {
     expect(root).not.toBeInstanceOf(RootRoute)
     expect(root).toBeInstanceOf(AlternativeRootRoute)
     expect(root.workspaces).toBeInstanceOf(WorkspacesRoute)
+    expect(root.workspaces.$parent).toBeInstanceOf(AlternativeRootRoute)
     expect(root.account).toBeInstanceOf(AccountRoute)
+    expect(root.account.$parent).toBeInstanceOf(AlternativeRootRoute)
     expect(root.studios).toBeInstanceOf(StudiosRoute)
+    expect(root.studios.$parent).toBeInstanceOf(AlternativeRootRoute)
   })
 
   it("should fail to update navigation tree if anchor doesn't exist", () => {


### PR DESCRIPTION
Fixes the following bug:

1. Host starts. Works fine.
1. Module A starts and add its navigation tree to the host. Works fine.
1. Module B starts and add its navigation tree to the host. The host's navigation tree doesn't change.

Actual problem: the algorithm to merge trees wasn't updating the reference to the parent after merging a route into a tree.