### PR TITLE
feat: introduces support for nested wildcard routes (modular navigation)

### DIFF
--- a/packages/cli/src/Codegen.ts
+++ b/packages/cli/src/Codegen.ts
@@ -62,7 +62,7 @@ export class Codegen {
     const name = this.keyToClassName.get(route.localKey)
     const parentName = route.parent ? this.keyToClassName.get(route.parent.localKey) : 'undefined'
     const params = route.parent ? `parent: ${parentName}` : ''
-    const path = route.path.map(p => typeof p === 'string' ? p : `{${p.name}}`).join('/')
+    const path = route.path.map(p => typeof p === 'string' ? p : `{${p.name}}`).join('/').replace(/\/\*\//g, '/')
     return `
       class ${name} extends Route<${parentName}, RouteParams['${route.localKey}']> {
         constructor(${params}) {

--- a/packages/cli/test/__snapshots__/generate.spec.ts.snap
+++ b/packages/cli/test/__snapshots__/generate.spec.ts.snap
@@ -210,6 +210,8 @@ interface RouteParams {
     'root': void,
     'root.account': void,
     'root.studios': { search?: string },
+    'root.studios.studio': { studioId: string },
+    'root.studios.studio.stacks': { studioId: string },
     'root.download': { platform?: 'mac' | 'debian' | 'windows' }
 }
 
@@ -254,6 +256,34 @@ class StudiosRoute extends Route<RootRoute, RouteParams['root.studios']> {
         )
     }
 
+    studio = new StudioRoute(this)
+}
+
+
+
+class StudioRoute extends Route<StudiosRoute, RouteParams['root.studios.studio']> {
+    constructor(parent: StudiosRoute) {
+        super(
+            'root.studios.studio',
+            '/studios/{studioId}/*', parent,
+            { studioId: 'string' },
+        )
+    }
+
+    stacks = new StacksRoute(this)
+}
+
+
+
+class StacksRoute extends Route<StudioRoute, RouteParams['root.studios.studio.stacks']> {
+    constructor(parent: StudioRoute) {
+        super(
+            'root.studios.studio.stacks',
+            '/studios/{studioId}/stacks/*', parent,
+            { studioId: 'string' },
+        )
+    }
+
 
 }
 
@@ -280,6 +310,8 @@ const routeByKey: RouteByKey = {
     'root': root,
     'root.account': root.account,
     'root.studios': root.studios,
+    'root.studios.studio': root.studios.studio,
+    'root.studios.studio.stacks': root.studios.studio.stacks,
     'root.download': root.download
 }
 
@@ -289,6 +321,8 @@ interface RouteByKey {
     'root': RootRoute,
     'root.account': AccountRoute,
     'root.studios': StudiosRoute,
+    'root.studios.studio': StudioRoute,
+    'root.studios.studio.stacks': StacksRoute,
     'root.download': DownloadRoute
 }
 

--- a/packages/cli/test/navigation.parent.yaml
+++ b/packages/cli/test/navigation.parent.yaml
@@ -2,5 +2,7 @@
   + account (/account/*):
   + studios (/studios/*):
     search: string
+    + studio (/{studioId}/*):
+      + stacks (/stacks/*):
   + download (/download):
     platform: string ('mac' | 'debian' | 'windows')


### PR DESCRIPTION
When two navigation trees were merged, a shallow copy of the source tree was made to the target tree. This was ok, since we never expected a route with a wildcard to have children.

This is not ok anymore, since, because of new Stackspot requirements, we'll need a host to specify a deep route created by a module.

This PR adds support for nested wildcard routes by deep copying a navigation tree to another.